### PR TITLE
feat: remember last inputs and tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ No external dependencies.
 - Pack: Build a `.ts4script` from a workspace folder.
 - Watch: Auto-pack on file changes via polling (no external libs).
 - Ignore list editor: Manage `.ts4ignore` patterns per workspace.
+- Remembers last used paths and the active tab between sessions.
 
 ## Run
 Double-click `ts4script_tool_gui.py` (or run `python ts4script_tool_gui.py`).


### PR DESCRIPTION
## Summary
- persist last used paths, watch interval, and active tab via a state file
- restore cached GUI state on startup
- document session caching in README

## Testing
- `python -m py_compile ts4script_tool_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6899d0878768832ba4edd00db84d993c